### PR TITLE
Fix activation area issue in door field

### DIFF
--- a/Code/Entities/DoorField.cs
+++ b/Code/Entities/DoorField.cs
@@ -28,6 +28,7 @@ namespace Celeste.Mod.CherryHelper
             Add(talkie = new TalkComponent(new Rectangle(0, 0, (int)Collider.Width, (int)Collider.Height), new Vector2(0.5f * Collider.Width, 0.5f * Collider.Height), OnEnter));
             talkie.Enabled = true;
             talkie.Visible = true;
+            talkie.PlayerMustBeFacing = false;
             base.Added(scene);
         }
         public DoorField(EntityData data, Vector2 offset) : this(data.Position + offset, data.Width, data.Height)


### PR DESCRIPTION
The door field was not letting you activate it if you were facing right unless you stood in the leftmost two tiles. This fix lets you use the talker from anywhere in the door field as intended. Closes #1.