### PR TITLE
Door Field cassette music fix

### DIFF
--- a/Code/Entities/DoorField.cs
+++ b/Code/Entities/DoorField.cs
@@ -99,6 +99,9 @@ namespace Celeste.Mod.CherryHelper
                     level.Session.Level = toLevel;
                     level.Session.RespawnPoint = level.GetSpawnPoint(spawnOffset + new Vector2(level.Bounds.Left, level.Bounds.Top));
                     level.LoadLevel(Player.IntroTypes.None);
+                    if (level.Tracker.GetEntity<CassetteBlockManager>() is { } blockManager) {
+                        blockManager.Get<TransitionListener>()?.OnOutBegin?.Invoke();
+                    }
                     Audio.SetMusicParam("fade", 1f);
                     Leader.RestoreStrawberries(level.Tracker.GetEntity<Player>().Leader);
                     level.Camera.Y -= 8f;


### PR DESCRIPTION
Bug reported [here](https://github.com/CommunalHelper/IsaGrabBag/issues/17). The issues link was wrong on the GB page lol.

Door field does a naive teleport, so it doesn't call transition listeners (which would reset cassette music). We probably don't want to add ALL transition routines because that could have unintended side effects on old maps, but this one is safe to special-case