### PR TITLE
Fix shadow dash invincibility ending early

### DIFF
--- a/Code/Entities/ShadowDashRefill.cs
+++ b/Code/Entities/ShadowDashRefill.cs
@@ -212,6 +212,7 @@ namespace Celeste.Mod.CherryHelper
             if (CherryHelper.Session.HasShadowDash)
             {
                 CherryHelper.Session.ShadowDashActive = true;
+                shadowEndDelayCoroutine?.Cancel();
                 shadowEndDelayCoroutine?.RemoveSelf();
             }
             CherryHelper.Session.HasShadowDash = false;


### PR DESCRIPTION
Bug reported [here](https://github.com/CommunalHelper/IsaGrabBag/issues/18) (the issues link was wrong on the GB page).

Shadow dash has a 0.03f leniency period after it ends before invincibility is disabled. Getting a new shadow dash refill is meant to end the disabling coroutine, but `RemoveSelf()` doesn't actually immediately end the coroutine as was intended. So, we call `Cancel()` first.

Verified fix via a TAS. This shouldn't have any effect besides a minor increase in leniency (i.e. not randomly killing you anymore), but I did run a TAS of Another Farewell Map C-side just to make sure no other strange effects happened.